### PR TITLE
Update Reactjs snippets.cson

### DIFF
--- a/snippets/Reactjs snippets.cson
+++ b/snippets/Reactjs snippets.cson
@@ -4,7 +4,7 @@
 
 # Github Repo : https://github.com/Lakston/atom-reactjs-snippets
 
-'.source.js.jsx':
+'.source.js':
 
 #######################
 # Import React and ReactDOM


### PR DESCRIPTION
Since we can write react in js, changing jsx to js will allow us to use snippet in JS